### PR TITLE
Mixer Input scaling and cli bug fixes

### DIFF
--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -101,14 +101,19 @@ typedef struct mixer_s
     int16_t max;               // lower bound of rule range -1000..1000%%
 } mixer_t;
 
-PG_DECLARE_ARRAY(mixer_t, MIXER_RULE_COUNT, mixerRules);
+typedef struct mixscale_s
+{
+    int16_t scale[MIXER_INPUT_COUNT];         // lower bound of rule range -1000..1000%%
+} mixscale_t;
 
+PG_DECLARE_ARRAY(mixer_t, MIXER_RULE_COUNT, mixerRules);
+PG_DECLARE(mixscale_t, mixerScales);
 
 extern FAST_RAM_ZERO_INIT uint8_t mixerActiveServos;
 extern FAST_RAM_ZERO_INIT uint8_t mixerActiveMotors;
 
 extern FAST_RAM_ZERO_INIT int16_t mixerOverride[MIXER_INPUT_COUNT];
-
+extern FAST_RAM_ZERO_INIT int16_t mixScales[MIXER_INPUT_COUNT];
 
 void mixerInit(void);
 void mixerInitProfile(void);

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -153,6 +153,7 @@
 #define PG_FREQ_CONFIG 554
 #define PG_HELI_MIXER 555
 #define PG_GOVERNOR_CONFIG 556
+#define PG_HELI_MIXER_SCALES 557
 
 // OSD configuration (subject to change)
 #define PG_OSD_FONT_CONFIG 2047


### PR DESCRIPTION
Mixer input scaling (CLI "mixscale") allows for adjusting the scaling for an input to the mixer without having to adjust all of the individual mixer lines.  This makes it possible to quickly tune the overall cyclic and collective pitch for a set mixer override value.  

Recommend setting 8 degrees of cyclic pitch using mixscale when the mixer override for the SR or SP inputs is set to 666.  After mixscale is set for 8 degrees, go ahead and adjust mixer override on the pitch or roll axis until you achieve your desired overall maximum cyclic pitch.  Then set pidsum_limit equal to the override value you chose.

Also, some CLI bugfixes.