### PR TITLE
Add Dockerfile and helper docker service.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.github
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:bionic
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get -y install \
+    build-essential \
+    curl \
+    git \
+    python
+
+RUN mkdir /heliflight
+WORKDIR /heliflight

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  heliflight:
+    build: .
+    volumes:
+      - ./:/heliflight


### PR DESCRIPTION
Add simple Docker build container. This will allow users on systems with Docker installed to check out the repo and build the firmware with:

```bash
docker compose run heliflight make arm_sdk_install
docker compose run heliflight make STM32F7X2
```

After this is merged I can update the wiki.